### PR TITLE
feat(manage-files): add OG screenshots tab

### DIFF
--- a/apps/admin/src/views/manage-files/index.tsx
+++ b/apps/admin/src/views/manage-files/index.tsx
@@ -35,7 +35,15 @@ import { HeaderActionButton } from '~/components/button/header-action-button'
 import { API_URL } from '~/constants/env'
 import { useLayout } from '~/layouts/content'
 
+import {
+  OG_SCREENSHOT_TAB_ICON,
+  OG_SCREENSHOT_TAB_KEY,
+  OG_SCREENSHOT_TAB_LABEL,
+  OgScreenshotsTab,
+} from './og-screenshots'
+
 type FileType = 'file' | 'icon' | 'image' | 'avatar'
+type TabKey = FileType | typeof OG_SCREENSHOT_TAB_KEY
 
 interface FileTypeConfig {
   key: FileType
@@ -51,30 +59,35 @@ const FILE_TYPE_CONFIGS: FileTypeConfig[] = [
   { key: 'file', label: '文件', icon: FileIcon, acceptImage: false },
 ]
 
+const isFileType = (key: TabKey): key is FileType =>
+  key !== OG_SCREENSHOT_TAB_KEY
+
 export default defineComponent({
   setup() {
-    const type = ref<FileType>('icon')
+    const activeTab = ref<TabKey>('icon')
     const list = ref<{ url: string; name: string; created?: number }[]>([])
     const loading = ref(false)
     const modalShow = ref(false)
 
     const currentConfig = computed(
       () =>
-        FILE_TYPE_CONFIGS.find((c) => c.key === type.value) ||
-        FILE_TYPE_CONFIGS[0],
+        FILE_TYPE_CONFIGS.find(
+          (c) => isFileType(activeTab.value) && c.key === activeTab.value,
+        ) || FILE_TYPE_CONFIGS[0],
     )
 
     const fetch = async () => {
+      if (!isFileType(activeTab.value)) return
       loading.value = true
       try {
-        const data = await filesApi.getByType(type.value)
+        const data = await filesApi.getByType(activeTab.value)
         list.value = data
       } finally {
         loading.value = false
       }
     }
 
-    watch(() => type.value, fetch)
+    watch(() => activeTab.value, fetch)
     onMounted(fetch)
 
     const checkUploadFile = async (data: {
@@ -108,7 +121,8 @@ export default defineComponent({
     }
 
     const handleDelete = async (name: string) => {
-      await filesApi.deleteByTypeAndName(type.value, name)
+      if (!isFileType(activeTab.value)) return
+      await filesApi.deleteByTypeAndName(activeTab.value, name)
       toast.success('删除成功')
       list.value = list.value.filter((item) => item.name !== name)
     }
@@ -123,25 +137,38 @@ export default defineComponent({
     }
 
     const { setActions } = useLayout()
-    setActions(
-      <HeaderActionButton
-        variant="info"
-        onClick={() => {
-          modalShow.value = true
-        }}
-        icon={<UploadIcon />}
-        name="上传文件"
-      />,
+    watch(
+      () => activeTab.value,
+      (tab) => {
+        if (isFileType(tab)) {
+          setActions(
+            <HeaderActionButton
+              variant="info"
+              onClick={() => {
+                modalShow.value = true
+              }}
+              icon={<UploadIcon />}
+              name="上传文件"
+            />,
+          )
+        } else {
+          setActions(null)
+        }
+      },
+      { immediate: true },
     )
 
     const isImageType = computed(() => currentConfig.value.acceptImage)
+    const isOgScreenshotTab = computed(
+      () => activeTab.value === OG_SCREENSHOT_TAB_KEY,
+    )
 
     return () => (
       <div class="flex h-full flex-col">
         <NTabs
-          value={type.value}
+          value={activeTab.value}
           onUpdateValue={(val) => {
-            type.value = val
+            activeTab.value = val as TabKey
           }}
           type="line"
           class="mb-4"
@@ -158,59 +185,75 @@ export default defineComponent({
               )}
             />
           ))}
+          <NTabPane
+            key={OG_SCREENSHOT_TAB_KEY}
+            name={OG_SCREENSHOT_TAB_KEY}
+            tab={() => (
+              <div class="flex items-center gap-2">
+                <OG_SCREENSHOT_TAB_ICON class="size-4" />
+                <span>{OG_SCREENSHOT_TAB_LABEL}</span>
+              </div>
+            )}
+          />
         </NTabs>
 
-        <div class="relative min-h-0 flex-1">
-          {loading.value ? (
-            <div class="flex h-64 items-center justify-center">
-              <NSpin size="large" />
-            </div>
-          ) : list.value.length === 0 ? (
-            <div class="flex h-64 items-center justify-center">
-              <NEmpty description="暂无文件">
-                {{
-                  extra: () => (
-                    <NButton
-                      size="small"
-                      onClick={() => {
-                        modalShow.value = true
-                      }}
-                    >
-                      上传文件
-                    </NButton>
-                  ),
-                }}
-              </NEmpty>
-            </div>
-          ) : (
-            <NScrollbar class="h-full max-h-[calc(100vh-220px)]">
-              {isImageType.value ? (
-                <div class="grid grid-cols-2 gap-4 p-1 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6">
-                  {list.value.map((item) => (
-                    <FileCard
-                      key={item.name}
-                      item={item}
-                      isImage={true}
-                      onDelete={() => handleDelete(item.name)}
-                      onCopy={() => handleCopyUrl(item.url)}
-                    />
-                  ))}
-                </div>
-              ) : (
-                <div class="flex flex-col gap-2 p-1">
-                  {list.value.map((item) => (
-                    <FileListItem
-                      key={item.name}
-                      item={item}
-                      onDelete={() => handleDelete(item.name)}
-                      onCopy={() => handleCopyUrl(item.url)}
-                    />
-                  ))}
-                </div>
-              )}
-            </NScrollbar>
-          )}
-        </div>
+        {isOgScreenshotTab.value ? (
+          <div class="min-h-0 flex-1">
+            <OgScreenshotsTab />
+          </div>
+        ) : (
+          <div class="relative min-h-0 flex-1">
+            {loading.value ? (
+              <div class="flex h-64 items-center justify-center">
+                <NSpin size="large" />
+              </div>
+            ) : list.value.length === 0 ? (
+              <div class="flex h-64 items-center justify-center">
+                <NEmpty description="暂无文件">
+                  {{
+                    extra: () => (
+                      <NButton
+                        size="small"
+                        onClick={() => {
+                          modalShow.value = true
+                        }}
+                      >
+                        上传文件
+                      </NButton>
+                    ),
+                  }}
+                </NEmpty>
+              </div>
+            ) : (
+              <NScrollbar class="h-full max-h-[calc(100vh-220px)]">
+                {isImageType.value ? (
+                  <div class="grid grid-cols-2 gap-4 p-1 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6">
+                    {list.value.map((item) => (
+                      <FileCard
+                        key={item.name}
+                        item={item}
+                        isImage={true}
+                        onDelete={() => handleDelete(item.name)}
+                        onCopy={() => handleCopyUrl(item.url)}
+                      />
+                    ))}
+                  </div>
+                ) : (
+                  <div class="flex flex-col gap-2 p-1">
+                    {list.value.map((item) => (
+                      <FileListItem
+                        key={item.name}
+                        item={item}
+                        onDelete={() => handleDelete(item.name)}
+                        onCopy={() => handleCopyUrl(item.url)}
+                      />
+                    ))}
+                  </div>
+                )}
+              </NScrollbar>
+            )}
+          </div>
+        )}
 
         <NModal
           closable
@@ -231,7 +274,7 @@ export default defineComponent({
             <NUpload
               class="flex w-full flex-col items-center"
               withCredentials
-              action={`${API_URL}/files/upload?type=${type.value}`}
+              action={`${API_URL}/files/upload?type=${activeTab.value}`}
               directory-dnd
               multiple
               accept={currentConfig.value.acceptImage ? 'image/*' : undefined}

--- a/apps/admin/src/views/manage-files/og-screenshots.tsx
+++ b/apps/admin/src/views/manage-files/og-screenshots.tsx
@@ -1,0 +1,285 @@
+import {
+  Camera,
+  Copy,
+  ExternalLink,
+  Image as ImageIcon,
+  RefreshCw,
+  Trash2,
+} from 'lucide-vue-next'
+import {
+  NButton,
+  NEmpty,
+  NImage,
+  NPagination,
+  NPopconfirm,
+  NScrollbar,
+  NSpin,
+  NTooltip,
+} from 'naive-ui'
+import { computed, defineComponent, ref } from 'vue'
+import { toast } from 'vue-sonner'
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/vue-query'
+
+import { enrichmentApi } from '~/api/enrichment'
+import { queryKeys } from '~/hooks/queries/keys'
+
+import { formatBytes } from '../enrichment/utils'
+
+const PAGE_SIZE = 24
+
+export const OgScreenshotsTab = defineComponent({
+  name: 'OgScreenshotsTab',
+  setup() {
+    const page = ref(1)
+    const queryClient = useQueryClient()
+
+    const params = computed(() => ({
+      page: page.value,
+      size: PAGE_SIZE,
+      sort: 'last_accessed' as const,
+      order: 'desc' as const,
+    }))
+
+    const { data, isPending, isFetching } = useQuery({
+      queryKey: computed(() =>
+        queryKeys.enrichment.screenshots.list(params.value),
+      ),
+      queryFn: () => enrichmentApi.screenshots.list(params.value),
+      placeholderData: (prev) => prev,
+      staleTime: 30_000,
+    })
+
+    const rows = computed(() => data.value?.data ?? [])
+    const pageCount = computed(() => data.value?.pagination.totalPage ?? 1)
+    const total = computed(() => data.value?.pagination.total ?? 0)
+
+    const invalidate = () =>
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.enrichment.screenshots.all(),
+      })
+
+    const deleteMutation = useMutation({
+      mutationFn: (enrichmentId: string) =>
+        enrichmentApi.screenshots.delete(enrichmentId),
+      onSuccess: () => {
+        toast.success('截图已删除')
+        invalidate()
+      },
+      onError: (err) => toast.error(`删除失败：${(err as Error).message}`),
+    })
+
+    const recaptureMutation = useMutation({
+      mutationFn: (enrichmentId: string) =>
+        enrichmentApi.screenshots.recapture(enrichmentId),
+      onSuccess: () => {
+        toast.success('重新抓取成功')
+        invalidate()
+      },
+      onError: (err) => toast.error(`重新抓取失败：${(err as Error).message}`),
+    })
+
+    const handleCopy = async (url: string) => {
+      try {
+        await navigator.clipboard.writeText(url)
+        toast.success('已复制截图链接')
+      } catch {
+        toast.error('复制失败')
+      }
+    }
+
+    return () => {
+      if (isPending.value) {
+        return (
+          <div class="flex h-64 items-center justify-center">
+            <NSpin size="large" />
+          </div>
+        )
+      }
+      if (rows.value.length === 0) {
+        return (
+          <div class="flex h-64 items-center justify-center">
+            <NEmpty description="尚无抓取截图" />
+          </div>
+        )
+      }
+      return (
+        <div class="flex h-full min-h-0 flex-col gap-3">
+          <div class="flex items-center justify-between text-xs text-neutral-500 dark:text-neutral-400">
+            <span class="tabular-nums">共 {total.value} 张</span>
+            {isFetching.value && <span class="text-neutral-400">加载中…</span>}
+          </div>
+          <NScrollbar class="min-h-0 flex-1">
+            <div class="grid grid-cols-2 gap-4 p-1 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6">
+              {rows.value.map((row) => (
+                <ScreenshotCard
+                  key={row.enrichmentId}
+                  row={row}
+                  onCopy={() => handleCopy(row.publicUrl)}
+                  onDelete={() => deleteMutation.mutate(row.enrichmentId)}
+                  onRecapture={() => recaptureMutation.mutate(row.enrichmentId)}
+                  recapturing={
+                    recaptureMutation.isPending.value &&
+                    recaptureMutation.variables.value === row.enrichmentId
+                  }
+                />
+              ))}
+            </div>
+          </NScrollbar>
+          <div class="flex justify-center pt-2">
+            <NPagination
+              page={page.value}
+              pageCount={pageCount.value}
+              onUpdatePage={(p) => (page.value = p)}
+              showSizePicker={false}
+            />
+          </div>
+        </div>
+      )
+    }
+  },
+})
+
+const ScreenshotCard = defineComponent({
+  name: 'OgScreenshotCard',
+  props: {
+    row: {
+      type: Object as () => import('~/models/enrichment').EnrichmentScreenshotJoinedRow,
+      required: true,
+    },
+    recapturing: Boolean,
+  },
+  emits: ['copy', 'delete', 'recapture'],
+  setup(props, { emit }) {
+    const errored = ref(false)
+    return () => {
+      const { row } = props
+      const hasImage = !!row.publicUrl && !errored.value
+      return (
+        <div class="group relative overflow-hidden rounded-lg border border-neutral-200 bg-white transition-all hover:border-neutral-300 hover:shadow-sm dark:border-neutral-800 dark:bg-neutral-900 dark:hover:border-neutral-700">
+          <div class="aspect-video overflow-hidden bg-neutral-50 dark:bg-neutral-800/50">
+            {hasImage ? (
+              <NImage
+                src={row.publicUrl}
+                objectFit="cover"
+                class="size-full"
+                showToolbar={false}
+                imgProps={{
+                  class: 'size-full object-cover',
+                  loading: 'lazy',
+                  onError: () => (errored.value = true),
+                }}
+              />
+            ) : (
+              <div class="flex size-full items-center justify-center">
+                <ImageIcon class="size-8 text-neutral-300 dark:text-neutral-600" />
+              </div>
+            )}
+          </div>
+
+          <div class="flex flex-col gap-0.5 px-2 py-1.5">
+            <span
+              class="line-clamp-1 text-xs font-medium text-neutral-800 dark:text-neutral-200"
+              title={row.title || row.url}
+            >
+              {row.title || row.url}
+            </span>
+            <div class="flex items-center justify-between text-xs text-neutral-500 dark:text-neutral-400">
+              <span class="tabular-nums">
+                {row.width}×{row.height}
+              </span>
+              <span class="tabular-nums">{formatBytes(row.bytes)}</span>
+            </div>
+          </div>
+
+          <div class="absolute inset-x-0 bottom-0 translate-y-full bg-gradient-to-t from-black/80 via-black/60 to-transparent p-3 pt-8 opacity-0 transition-all group-hover:translate-y-0 group-hover:opacity-100">
+            <p class="mb-2 truncate text-xs text-white/90">{row.url}</p>
+            <div class="flex gap-1">
+              <NTooltip>
+                {{
+                  trigger: () => (
+                    <NButton
+                      size="tiny"
+                      quaternary
+                      class="!text-white hover:!bg-white/20"
+                      onClick={() => emit('copy')}
+                    >
+                      {{ icon: () => <Copy class="size-3.5" /> }}
+                    </NButton>
+                  ),
+                  default: () => '复制截图链接',
+                }}
+              </NTooltip>
+              <NTooltip>
+                {{
+                  trigger: () => (
+                    <a
+                      href={row.url}
+                      target="_blank"
+                      rel="noreferrer"
+                      class="inline-flex size-6 items-center justify-center rounded text-white hover:bg-white/20"
+                    >
+                      <ExternalLink class="size-3.5" />
+                    </a>
+                  ),
+                  default: () => '访问原页面',
+                }}
+              </NTooltip>
+              <NPopconfirm onPositiveClick={() => emit('recapture')}>
+                {{
+                  trigger: () => (
+                    <NTooltip>
+                      {{
+                        trigger: () => (
+                          <NButton
+                            size="tiny"
+                            quaternary
+                            loading={props.recapturing}
+                            class="!text-white hover:!bg-white/20"
+                          >
+                            {{
+                              icon: () => <RefreshCw class="size-3.5" />,
+                            }}
+                          </NButton>
+                        ),
+                        default: () => '重新抓取',
+                      }}
+                    </NTooltip>
+                  ),
+                  default: () =>
+                    '重新抓取将打开无头浏览器请求页面并覆盖现有截图，确定吗？',
+                }}
+              </NPopconfirm>
+              <NPopconfirm onPositiveClick={() => emit('delete')}>
+                {{
+                  trigger: () => (
+                    <NTooltip>
+                      {{
+                        trigger: () => (
+                          <NButton
+                            size="tiny"
+                            quaternary
+                            class="!text-red-400 hover:!bg-red-500/20"
+                          >
+                            {{ icon: () => <Trash2 class="size-3.5" /> }}
+                          </NButton>
+                        ),
+                        default: () => '删除截图',
+                      }}
+                    </NTooltip>
+                  ),
+                  default: () =>
+                    `确定要删除 "${row.title || row.url}" 的截图吗？`,
+                }}
+              </NPopconfirm>
+            </div>
+          </div>
+        </div>
+      )
+    }
+  },
+})
+
+export const OG_SCREENSHOT_TAB_KEY = 'og-screenshot'
+export const OG_SCREENSHOT_TAB_ICON = Camera
+export const OG_SCREENSHOT_TAB_LABEL = 'OG 截图'


### PR DESCRIPTION
## Summary
- Surface enrichment-captured page screenshots inside the file management page so admins can review what the headless browser pulled for each link card, without leaving the file workflow.
- Grid view with thumbnail, title/URL, dimensions, bytes; hover actions: copy screenshot URL, open source page, recapture (popconfirm), delete (popconfirm).
- 24 / page, sorted by \`last_accessed desc\`; reuses \`enrichmentApi.screenshots\` and \`queryKeys.enrichment.screenshots\` so cache invalidates consistently with the existing master-detail screenshots view at \`/enrichment?source=screenshots\`.
- Upload header button is suppressed on this tab — screenshots are pipeline-produced, not user-uploaded.

Pairs with mx-space/core#2724 (Open Graph browser-mode hardening).

## Test plan
- [x] \`npx tsc --noEmit\` — clean
- [x] \`npx biome check\` on changed files — clean
- [ ] Visual smoke: open Files page → switch to "OG 截图" tab → grid renders, pagination works, recapture / delete fire correctly